### PR TITLE
添加 Docker Compose 配置文件

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,63 @@
+services:
+
+    consul:
+        image: hashicorp/consul:latest
+        ports:
+            - 8500:8500
+    etcd:
+        image: bitnami/etcd:3.5.14
+        container_name: etcd
+        ports:
+            - "2379:2379"
+            - "2380:2380"
+        environment:
+            - ALLOW_SINGLE_CLUSTER=true
+            - TZ=Asia/Shanghai
+            - ALLOW_NONE_AUTHENTICATION=yes
+    nacos:
+        image: nacos/nacos-server:v2.4.0
+        container_name: nacos
+        ports:
+            - "8848:8848"
+            - "9849:9849"
+            - "9849:9849"
+        volumes:
+            -   ./nacos/logs:/home/nacos/logs
+            -  ./nacos/data:/home/nacos/data
+        environment:
+            - PREFER_HOST_MODE=hostname
+            - MODE=standalone
+        networks:
+            - micro-service-net
+    sentinel:
+        image: bladex/sentinel-dashboard:1.8.7
+        container_name: sentinel
+        ports:
+            - "8858:8858"
+        networks:
+            - micro-service-net
+    redis:
+        image: redis:6.2.6
+        container_name: redis
+        ports:
+            - "6379:6379"
+        networks:
+            - micro-service-net
+    mysql:
+        image: mysql:8.0 # 使用MySQL官方镜像，版本8
+        restart: always # 容器退出后总是重启
+        environment:
+            MYSQL_ROOT_PASSWORD: 88888888 # 设置root用户的密码，生产环境中请使用更复杂的密码
+            MYSQL_DATABASE: douyin-shop # 初始化时创建的数据库名称
+            MYSQL_USER: douyin-shop # 创建的新用户
+            MYSQL_PASSWORD: 88888888 # 新用户的密码
+        ports:
+            - "3306:3306" # 映射容器的3306端口到主机的3306端口
+        volumes:
+            - db_data:/var/lib/mysql # 挂载宿主机的目录到容器的MySQL数据目录，用于持久化数据
+
+networks:
+    micro-service-net:
+        driver: bridge
+volumes:
+    db_data:


### PR DESCRIPTION

This pull request introduces a new `compose.yaml` file to configure multiple services using Docker Compose. The file sets up several essential services for a microservices architecture, including Consul, etcd, Nacos, Sentinel, Redis, and MySQL.

Key changes include:

* **Service Configuration:**
  * Added Consul service with the latest image and port mapping.
  * Configured etcd service with Bitnami image, specific environment variables, and port mapping.
  * Added Nacos service with volume mounts, environment settings, and port mapping.
  * Included Sentinel service with the specified image and network configuration.
  * Configured Redis service with the latest image and network settings.
  * Set up MySQL service with environment variables for user credentials and database initialization, along with volume mounts for data persistence.

* **Network and Volume Configuration:**
  * Defined a custom bridge network named `micro-service-net` for inter-service communication.
  * Created a volume named `db_data` for MySQL data persistence.