### PR TITLE
修复订单时间戳，使用 Unix 时间戳替代秒数

### DIFF
--- a/app/order/biz/service/list_order.go
+++ b/app/order/biz/service/list_order.go
@@ -79,10 +79,10 @@ func (s *ListOrderService) Run(req *order.ListOrderReq) (resp *order.ListOrderRe
 			orderItems = append(orderItems, orderItem)
 		}
 
-		createdTime := int32(orderModel.CreatedAt.Second())
+		createdTime := int32(orderModel.CreatedAt.Unix())
 		var canceledTime int32
 		if orderModel.CanceledAt != nil {
-			canceledTime = int32(orderModel.CanceledAt.Second())
+			canceledTime = int32(orderModel.CanceledAt.Unix())
 		}
 
 		singleOrderResult := &order.Order{


### PR DESCRIPTION
This pull request includes a change to the `ListOrderService` in the `list_order.go` file. The change updates how `createdTime` and `canceledTime` are calculated by switching from using the `Second()` method to the `Unix()` method.

* [`app/order/biz/service/list_order.go`](diffhunk://#diff-e88236acc395b4ea4e4f4a4dd17025001d099d2b5c4c760724105d2b8259b351L82-R85): Updated the calculation of `createdTime` and `canceledTime` to use `Unix()` instead of `Second()`.